### PR TITLE
Add UTI detection with verbose output and DRY CLI architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,10 @@ temp_dir = /path/to/custom/temp
    - Text data → copies as text
    - Binary data → saves to temp file, copies reference
 
-3. **MIME Type Detection**:
-   - Uses content-based detection, not file extensions
+3. **Smart Type Detection**:
+   - Uses hybrid detection: UTI → MIME → content analysis
+   - UTI detection leverages macOS's native type system for maximum reliability
+   - MIME type detection uses content-based analysis, not file extensions
    - Anything with MIME type `text/*` is treated as text
    - This means `.log`, `.conf`, `.json`, etc. are correctly identified as text
    - Binary files are identified by their actual content (e.g., PNG magic bytes)

--- a/clippy.go
+++ b/clippy.go
@@ -1,6 +1,6 @@
 // Package clippy provides smart clipboard operations for macOS.
 // It automatically detects whether to copy file content or file references
-// based on MIME type detection.
+// using hybrid detection: UTI -> MIME -> mimetype fallback for maximum reliability.
 package clippy
 
 import (
@@ -10,42 +10,97 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/gabriel-vasile/mimetype"
 	"github.com/neilberkman/clippy/pkg/clipboard"
 )
 
+// CopyResult contains information about what was copied and how
+type CopyResult struct {
+	Method   string // "UTI", "MIME", or "content"
+	Type     string // The detected type (UTI or MIME)
+	AsText   bool   // Whether content was copied as text
+	FilePath string // The file path that was copied
+}
+
 // Copy intelligently copies a file to clipboard.
 // Text files copy their content, binary files copy file references.
+// Uses hybrid detection: UTI -> MIME -> mimetype fallback.
 func Copy(path string) error {
+	_, err := CopyWithResult(path)
+	return err
+}
+
+// CopyWithResult is like Copy but returns information about the detection method used
+func CopyWithResult(path string) (*CopyResult, error) {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
-		return fmt.Errorf("invalid path %s: %w", path, err)
+		return nil, fmt.Errorf("invalid path %s: %w", path, err)
 	}
 
 	// Check if file exists
 	if _, err := os.Stat(absPath); os.IsNotExist(err) {
-		return fmt.Errorf("file not found: %s", absPath)
+		return nil, fmt.Errorf("file not found: %s", absPath)
 	}
 
-	// Detect MIME type
+	// Try UTI detection first (more reliable for macOS)
+	if uti, ok := clipboard.GetUTIForFile(absPath); ok {
+		// For dynamic UTIs (unknown types), skip to MIME detection
+		if strings.HasPrefix(uti, "dyn.") {
+			// Fall through to MIME detection
+		} else if isTextUTI(uti) {
+			content, err := os.ReadFile(absPath)
+			if err != nil {
+				return nil, fmt.Errorf("could not read file content %s: %w", absPath, err)
+			}
+			clipboard.CopyText(string(content))
+			return &CopyResult{
+				Method:   "UTI",
+				Type:     uti,
+				AsText:   true,
+				FilePath: absPath,
+			}, nil
+		} else {
+			// Non-text UTI, copy as file reference
+			clipboard.CopyFile(absPath)
+			return &CopyResult{
+				Method:   "UTI",
+				Type:     uti,
+				AsText:   false,
+				FilePath: absPath,
+			}, nil
+		}
+	}
+
+	// Fallback to MIME type detection
 	mtype, err := mimetype.DetectFile(absPath)
 	if err != nil {
-		return fmt.Errorf("could not detect file type for %s: %w", absPath, err)
+		return nil, fmt.Errorf("could not detect file type for %s: %w", absPath, err)
 	}
 
 	// Text files: copy content, others: copy file reference
 	if strings.HasPrefix(mtype.String(), "text/") {
 		content, err := os.ReadFile(absPath)
 		if err != nil {
-			return fmt.Errorf("could not read file content %s: %w", absPath, err)
+			return nil, fmt.Errorf("could not read file content %s: %w", absPath, err)
 		}
 		clipboard.CopyText(string(content))
+		return &CopyResult{
+			Method:   "MIME",
+			Type:     mtype.String(),
+			AsText:   true,
+			FilePath: absPath,
+		}, nil
 	} else {
 		clipboard.CopyFile(absPath)
+		return &CopyResult{
+			Method:   "MIME",
+			Type:     mtype.String(),
+			AsText:   false,
+			FilePath: absPath,
+		}, nil
 	}
-
-	return nil
 }
 
 // CopyMultiple copies multiple files to clipboard as file references.
@@ -80,6 +135,7 @@ func CopyText(text string) {
 
 // CopyData copies data from a reader to clipboard.
 // Text data is copied as text, binary data is saved to a temp file.
+// Uses MIME type detection for content analysis.
 func CopyData(reader io.Reader) error {
 	return CopyDataWithTempDir(reader, "")
 }
@@ -121,11 +177,93 @@ func CopyDataWithTempDir(reader io.Reader, tempDir string) error {
 }
 
 // GetText returns text content from clipboard.
+// Uses hybrid detection for better reliability.
 func GetText() (string, bool) {
+	// Try hybrid detection first
+	if content, err := clipboard.GetClipboardContent(); err == nil {
+		if content.IsText {
+			return string(content.Data), true
+		}
+	}
+
+	// Fallback to simple text detection
 	return clipboard.GetText()
 }
 
 // GetFiles returns file paths from clipboard.
+// Uses hybrid detection for better reliability.
 func GetFiles() []string {
+	// Try hybrid detection first
+	if content, err := clipboard.GetClipboardContent(); err == nil {
+		if content.IsFile {
+			return []string{content.FilePath}
+		}
+	}
+
+	// Fallback to simple file detection
 	return clipboard.GetFiles()
+}
+
+// isTextUTI checks if a UTI represents text content using macOS UTI system
+func isTextUTI(uti string) bool {
+	// Use macOS UTI system to check if this UTI conforms to text types
+	conformsToText := clipboard.UTIConformsTo(uti, "public.text") ||
+		clipboard.UTIConformsTo(uti, "public.plain-text") ||
+		clipboard.UTIConformsTo(uti, "public.source-code")
+
+	// For dynamic UTIs (unknown types), let MIME detection handle it
+	if strings.HasPrefix(uti, "dyn.") {
+		return false
+	}
+
+	return conformsToText
+}
+
+// CleanupTempFiles removes old temporary files that are no longer in clipboard
+func CleanupTempFiles(tempDir string, verbose bool) {
+	// Get current clipboard files
+	files := GetFiles()
+
+	// Build a map of clipboard files for quick lookup
+	clipboardMap := make(map[string]bool)
+	for _, file := range files {
+		clipboardMap[file] = true
+	}
+
+	// Find only clippy temp files using glob
+	if tempDir == "" {
+		tempDir = os.TempDir()
+	}
+	pattern := filepath.Join(tempDir, "clippy-*")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return
+	}
+
+	for _, fullPath := range matches {
+		info, err := os.Stat(fullPath)
+		if err != nil {
+			continue
+		}
+
+		age := time.Since(info.ModTime())
+
+		// Check if this file is in the clipboard
+		if !clipboardMap[fullPath] {
+			// Only delete files older than 5 minutes to avoid race conditions
+			// with parallel clippy/pasty operations
+			if age >= 5*time.Minute {
+				if verbose {
+					name := filepath.Base(fullPath)
+					fmt.Fprintf(os.Stderr, "Cleaning up old temp file: %s (created %v ago)\n",
+						name, age.Round(time.Minute))
+				}
+				if err := os.Remove(fullPath); err != nil {
+					if verbose {
+						fmt.Fprintf(os.Stderr, "Warning: Failed to remove temp file %s: %v\n", filepath.Base(fullPath), err)
+					}
+				}
+			}
+		}
+	}
 }

--- a/pkg/clipboard/clipboard.go
+++ b/pkg/clipboard/clipboard.go
@@ -2,10 +2,12 @@ package clipboard
 
 /*
 #cgo CFLAGS: -x objective-c
-#cgo LDFLAGS: -framework Foundation -framework AppKit
+#cgo LDFLAGS: -framework Foundation -framework AppKit -framework CoreServices -framework UniformTypeIdentifiers
 #import <Foundation/Foundation.h>
 #import <AppKit/NSPasteboard.h>
 #import <AppKit/NSApplication.h>
+#import <CoreServices/CoreServices.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 // Function to copy a file reference to the clipboard
 void copyFile(const char *path) {
@@ -95,9 +97,133 @@ void freeFilePaths(char **paths, int count) {
 void freeString(char *str) {
     if (str) free(str);
 }
+
+// Get UTI for a file path
+char* getUTIForFile(const char* path) {
+    @autoreleasepool {
+        CFStringRef pathRef = CFStringCreateWithCString(NULL, path, kCFStringEncodingUTF8);
+        CFURLRef urlRef = CFURLCreateWithFileSystemPath(NULL, pathRef, kCFURLPOSIXPathStyle, false);
+        CFRelease(pathRef);
+        if (urlRef == NULL) return NULL;
+
+        CFStringRef utiRef = NULL;
+        CFStringRef pathExtension = CFURLCopyPathExtension(urlRef);
+        if (pathExtension) {
+            // Use the newer API when available, fallback to deprecated API
+            if (@available(macOS 11.0, *)) {
+                NSString *extension = (__bridge NSString*)pathExtension;
+                UTType *utType = [UTType typeWithFilenameExtension:extension];
+                if (utType) {
+                    utiRef = CFStringCreateCopy(NULL, (__bridge CFStringRef)utType.identifier);
+                }
+            } else {
+                #pragma clang diagnostic push
+                #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                utiRef = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension,
+                                                              pathExtension,
+                                                              NULL);
+                #pragma clang diagnostic pop
+            }
+            CFRelease(pathExtension);
+        }
+        CFRelease(urlRef);
+
+        if (utiRef == NULL) return NULL;
+
+        const char* uti = CFStringGetCStringPtr(utiRef, kCFStringEncodingUTF8);
+        char* result = uti ? strdup(uti) : NULL;
+        CFRelease(utiRef);
+        return result;
+    }
+}
+
+// Get available types on clipboard
+char** getClipboardTypes(int *count) {
+    @autoreleasepool {
+        [NSApplication sharedApplication]; // Initialize the app context
+        NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+        NSArray *types = [pasteboard types];
+
+        *count = (int)[types count];
+        if (*count == 0) return NULL;
+
+        char **typeStrings = (char**)malloc(sizeof(char*) * (*count));
+        for (int i = 0; i < *count; i++) {
+            NSString *type = types[i];
+            const char *typeStr = [type UTF8String];
+            typeStrings[i] = strdup(typeStr);
+        }
+
+        return typeStrings;
+    }
+}
+
+// Get clipboard data for a specific type
+char* getClipboardDataForType(const char* type, int *length) {
+    @autoreleasepool {
+        [NSApplication sharedApplication]; // Initialize the app context
+        NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+        NSString *typeString = [NSString stringWithUTF8String:type];
+        NSData *data = [pasteboard dataForType:typeString];
+
+        if (data == nil) {
+            *length = 0;
+            return NULL;
+        }
+
+        *length = (int)[data length];
+        char *result = (char*)malloc(*length);
+        [data getBytes:result length:*length];
+        return result;
+    }
+}
+
+// Check if clipboard contains a specific type
+int clipboardContainsType(const char* type) {
+    @autoreleasepool {
+        [NSApplication sharedApplication]; // Initialize the app context
+        NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+        NSString *typeString = [NSString stringWithUTF8String:type];
+        NSArray *types = [pasteboard types];
+        return [types containsObject:typeString] ? 1 : 0;
+    }
+}
+
+// Check if a UTI conforms to a parent type (e.g., check if UTI is text)
+int utiConformsTo(const char* uti, const char* parentType) {
+    @autoreleasepool {
+        CFStringRef utiRef = CFStringCreateWithCString(NULL, uti, kCFStringEncodingUTF8);
+        CFStringRef parentRef = CFStringCreateWithCString(NULL, parentType, kCFStringEncodingUTF8);
+
+        int result = 0;
+
+        // Use the newer API when available
+        if (@available(macOS 11.0, *)) {
+            NSString *utiString = (__bridge NSString*)utiRef;
+            NSString *parentString = (__bridge NSString*)parentRef;
+            UTType *utType = [UTType typeWithIdentifier:utiString];
+            UTType *parentUTType = [UTType typeWithIdentifier:parentString];
+
+            if (utType && parentUTType) {
+                result = [utType conformsToType:parentUTType] ? 1 : 0;
+            }
+        } else {
+            // Fallback to deprecated API
+            #pragma clang diagnostic push
+            #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+            result = UTTypeConformsTo(utiRef, parentRef) ? 1 : 0;
+            #pragma clang diagnostic pop
+        }
+
+        CFRelease(utiRef);
+        CFRelease(parentRef);
+        return result;
+    }
+}
 */
 import "C"
 import (
+	"fmt"
 	"unsafe"
 )
 
@@ -154,4 +280,198 @@ func GetText() (string, bool) {
 	}
 	defer C.freeString(cText)
 	return C.GoString(cText), true
+}
+
+// GetUTIForFile returns the UTI (Uniform Type Identifier) for a file path
+func GetUTIForFile(path string) (string, bool) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	cUTI := C.getUTIForFile(cPath)
+	if cUTI == nil {
+		return "", false
+	}
+	defer C.freeString(cUTI)
+
+	return C.GoString(cUTI), true
+}
+
+// GetClipboardTypes returns all available types on clipboard
+func GetClipboardTypes() []string {
+	var count C.int
+	cTypes := C.getClipboardTypes(&count)
+	if cTypes == nil {
+		return nil
+	}
+	defer C.freeFilePaths(cTypes, count)
+
+	// Convert C array to Go slice
+	length := int(count)
+	cTypeArray := (*[1 << 30]*C.char)(unsafe.Pointer(cTypes))[:length:length]
+
+	types := make([]string, length)
+	for i := 0; i < length; i++ {
+		types[i] = C.GoString(cTypeArray[i])
+	}
+
+	return types
+}
+
+// GetClipboardDataForType returns data for a specific type from clipboard
+func GetClipboardDataForType(typeStr string) ([]byte, bool) {
+	cType := C.CString(typeStr)
+	defer C.free(unsafe.Pointer(cType))
+
+	var length C.int
+	cData := C.getClipboardDataForType(cType, &length)
+	if cData == nil {
+		return nil, false
+	}
+	defer C.free(unsafe.Pointer(cData))
+
+	// Convert C data to Go byte slice
+	data := C.GoBytes(unsafe.Pointer(cData), length)
+	return data, true
+}
+
+// ContainsType checks if clipboard contains a specific type
+func ContainsType(typeStr string) bool {
+	cType := C.CString(typeStr)
+	defer C.free(unsafe.Pointer(cType))
+
+	return C.clipboardContainsType(cType) == 1
+}
+
+// UTIConformsTo checks if a UTI conforms to a parent type using macOS UTI system
+func UTIConformsTo(uti, parentType string) bool {
+	cUTI := C.CString(uti)
+	defer C.free(unsafe.Pointer(cUTI))
+
+	cParent := C.CString(parentType)
+	defer C.free(unsafe.Pointer(cParent))
+
+	return C.utiConformsTo(cUTI, cParent) == 1
+}
+
+// ClipboardContent represents the content and type information from clipboard
+type ClipboardContent struct {
+	Type     string // UTI or MIME type
+	Data     []byte // Raw data
+	IsText   bool   // Whether this is text content
+	IsFile   bool   // Whether this is file reference
+	FilePath string // File path if IsFile is true
+}
+
+// GetClipboardContent returns clipboard content with smart type detection
+// Uses hybrid approach: UTI -> MIME -> mimetype fallback
+func GetClipboardContent() (*ClipboardContent, error) {
+	// Priority 1: Check for file URLs (highest reliability)
+	if files := GetFiles(); len(files) > 0 {
+		// For multiple files, just return info about the first one
+		filePath := files[0]
+		uti, _ := GetUTIForFile(filePath)
+		return &ClipboardContent{
+			Type:     uti,
+			IsFile:   true,
+			FilePath: filePath,
+		}, nil
+	}
+
+	// Priority 2: Check for text content
+	if text, ok := GetText(); ok {
+		return &ClipboardContent{
+			Type:   "public.utf8-plain-text",
+			Data:   []byte(text),
+			IsText: true,
+		}, nil
+	}
+
+	// Priority 3: Check for rich UTI types on clipboard
+	types := GetClipboardTypes()
+	for _, typeStr := range types {
+		// Look for specific image types first
+		if isImageUTI(typeStr) {
+			if data, ok := GetClipboardDataForType(typeStr); ok {
+				return &ClipboardContent{
+					Type:   typeStr,
+					Data:   data,
+					IsText: false,
+				}, nil
+			}
+		}
+
+		// Look for other rich content types
+		if isRichContentUTI(typeStr) {
+			if data, ok := GetClipboardDataForType(typeStr); ok {
+				return &ClipboardContent{
+					Type:   typeStr,
+					Data:   data,
+					IsText: false,
+				}, nil
+			}
+		}
+	}
+
+	// Priority 4: Check for generic types like public.data
+	for _, typeStr := range types {
+		if typeStr == "public.data" || typeStr == "public.content" {
+			if data, ok := GetClipboardDataForType(typeStr); ok {
+				// Use mimetype detection as fallback
+				return &ClipboardContent{
+					Type:   typeStr,
+					Data:   data,
+					IsText: false,
+				}, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no supported content found on clipboard")
+}
+
+// isImageUTI checks if a UTI represents an image type
+func isImageUTI(uti string) bool {
+	imageUTIs := []string{
+		"public.png",
+		"public.jpeg",
+		"public.tiff",
+		"public.gif",
+		"public.bmp",
+		"public.webp",
+		"public.heic",
+		"public.svg-image",
+	}
+
+	for _, imageUTI := range imageUTIs {
+		if uti == imageUTI {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isRichContentUTI checks if a UTI represents rich content
+func isRichContentUTI(uti string) bool {
+	richUTIs := []string{
+		"public.pdf",
+		"public.rtf",
+		"public.html",
+		"public.xml",
+		"public.json",
+		"public.zip-archive",
+		"public.tar-archive",
+		"public.mp3",
+		"public.mp4",
+		"public.mpeg-4",
+		"public.quicktime-movie",
+	}
+
+	for _, richUTI := range richUTIs {
+		if uti == richUTI {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/clipboard/clipboard_test.go
+++ b/pkg/clipboard/clipboard_test.go
@@ -1,0 +1,228 @@
+package clipboard
+
+import (
+	"testing"
+)
+
+func TestGetUTIForFile(t *testing.T) {
+	tests := []struct {
+		name        string
+		filePath    string
+		expectedUTI string
+		shouldExist bool
+	}{
+		{
+			name:        "PNG file",
+			filePath:    "../../test-files/minimal.png",
+			expectedUTI: "public.png",
+			shouldExist: true,
+		},
+		{
+			name:        "PDF file",
+			filePath:    "../../test-files/test.pdf",
+			expectedUTI: "com.adobe.pdf",
+			shouldExist: true,
+		},
+		{
+			name:        "Text file",
+			filePath:    "../../test-files/sample.txt",
+			expectedUTI: "public.plain-text",
+			shouldExist: true,
+		},
+		{
+			name:        "Elixir code file",
+			filePath:    "../../test-files/code.elixir",
+			expectedUTI: "public.text", // Generic text type for unknown extensions
+			shouldExist: true,
+		},
+		{
+			name:        "Unknown extension file",
+			filePath:    "/some/path/file.xyz",
+			expectedUTI: "",
+			shouldExist: true, // UTI detection works on extension, not file existence
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uti, exists := GetUTIForFile(tt.filePath)
+
+			if exists != tt.shouldExist {
+				t.Errorf("GetUTIForFile(%s) existence = %v, want %v", tt.filePath, exists, tt.shouldExist)
+			}
+
+			if tt.shouldExist && uti == "" {
+				t.Errorf("GetUTIForFile(%s) returned empty UTI but should exist", tt.filePath)
+			}
+
+			if tt.shouldExist && tt.expectedUTI != "" && uti != tt.expectedUTI {
+				t.Logf("GetUTIForFile(%s) = %s, expected %s (may be system-dependent)", tt.filePath, uti, tt.expectedUTI)
+			}
+		})
+	}
+}
+
+func TestClipboardTypes(t *testing.T) {
+	// Put some text on clipboard first
+	CopyText("Test text for clipboard types")
+
+	types := GetClipboardTypes()
+	if len(types) == 0 {
+		t.Error("Expected clipboard to have types after copying text")
+	}
+
+	// Should contain text type
+	found := false
+	for _, typeStr := range types {
+		if typeStr == "public.utf8-plain-text" || typeStr == "NSStringPboardType" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("Expected clipboard to contain text type, got: %v", types)
+	}
+}
+
+func TestContainsType(t *testing.T) {
+	// Put text on clipboard
+	CopyText("Test text for type checking")
+
+	// Should contain text type
+	if !ContainsType("public.utf8-plain-text") && !ContainsType("NSStringPboardType") {
+		t.Error("Expected clipboard to contain text type")
+	}
+
+	// Should not contain image type
+	if ContainsType("public.png") {
+		t.Error("Expected clipboard to not contain PNG type")
+	}
+}
+
+func TestGetClipboardContent(t *testing.T) {
+	// Test with text content
+	CopyText("Test text content")
+
+	content, err := GetClipboardContent()
+	if err != nil {
+		t.Fatalf("GetClipboardContent() error = %v", err)
+	}
+
+	if !content.IsText {
+		t.Error("Expected content to be text")
+	}
+
+	if string(content.Data) != "Test text content" {
+		t.Errorf("Expected content data = 'Test text content', got '%s'", string(content.Data))
+	}
+
+	// Test with file reference - need absolute path
+	absPath := "/Users/neil/xuku/clippy/test-files/minimal.png"
+	CopyFile(absPath)
+
+	content, err = GetClipboardContent()
+	if err != nil {
+		t.Fatalf("GetClipboardContent() error = %v", err)
+	}
+
+	if !content.IsFile {
+		t.Error("Expected content to be file")
+	}
+
+	if content.FilePath == "" {
+		t.Error("Expected file path to be set")
+	}
+}
+
+func TestImageUTIDetection(t *testing.T) {
+	tests := []struct {
+		uti      string
+		expected bool
+	}{
+		{"public.png", true},
+		{"public.jpeg", true},
+		{"public.tiff", true},
+		{"public.gif", true},
+		{"public.pdf", false},
+		{"public.plain-text", false},
+		{"public.data", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.uti, func(t *testing.T) {
+			result := isImageUTI(tt.uti)
+			if result != tt.expected {
+				t.Errorf("isImageUTI(%s) = %v, want %v", tt.uti, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRichContentUTIDetection(t *testing.T) {
+	tests := []struct {
+		uti      string
+		expected bool
+	}{
+		{"public.pdf", true},
+		{"public.html", true},
+		{"public.json", true},
+		{"public.zip-archive", true},
+		{"public.mp4", true},
+		{"public.png", false},
+		{"public.plain-text", false},
+		{"public.data", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.uti, func(t *testing.T) {
+			result := isRichContentUTI(tt.uti)
+			if result != tt.expected {
+				t.Errorf("isRichContentUTI(%s) = %v, want %v", tt.uti, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestUTIConformance(t *testing.T) {
+	tests := []struct {
+		name       string
+		uti        string
+		parentType string
+		expected   bool
+	}{
+		{
+			name:       "Plain text conforms to text",
+			uti:        "public.plain-text",
+			parentType: "public.text",
+			expected:   true,
+		},
+		{
+			name:       "C source conforms to source code",
+			uti:        "public.c-source",
+			parentType: "public.source-code",
+			expected:   true,
+		},
+		{
+			name:       "PNG does not conform to text",
+			uti:        "public.png",
+			parentType: "public.text",
+			expected:   false,
+		},
+		{
+			name:       "JSON should conform to text",
+			uti:        "public.json",
+			parentType: "public.text",
+			expected:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := UTIConformsTo(tt.uti, tt.parentType)
+			if result != tt.expected {
+				t.Errorf("UTIConformsTo(%s, %s) = %v, want %v", tt.uti, tt.parentType, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
UTI Detection Enhancement:
- Implement hybrid detection: UTI → MIME → mimetype fallback for maximum reliability
- Add Core Services and UniformTypeIdentifiers framework support
- Use proper macOS UTI hierarchy system with UTIConformsTo() for text detection
- Dynamic UTIs (unknown extensions) fall back to MIME detection gracefully
- Add comprehensive test coverage for all UTI functionality

CLI Architecture Improvements:
- CLI now uses library functions exclusively (fully DRY)
- Add CopyWithResult() to show detection method in verbose output
- Verbose output shows 'UTI: public.plain-text' vs 'MIME: text/plain'
- CLI is now thin interface: flags → library → verbose output
- Move CleanupTempFiles() to library for complete DRY architecture

Benefits:
- More reliable type detection using native macOS UTI system
- Better accuracy for native Mac apps (rich UTI types)
- Graceful fallback for cross-platform apps (MIME detection)
- Centralized logic in library with comprehensive testing
- CLI demonstrates detection method used for user confidence