### PR TITLE
Fix ParseDuration to reject negative durations and improve GetBrowserDownloadDir fallback

### DIFF
--- a/pkg/recent/recent.go
+++ b/pkg/recent/recent.go
@@ -68,7 +68,8 @@ func GetDefaultDownloadDirs() []string {
 func GetBrowserDownloadDir() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return filepath.Join(homeDir, "Downloads")
+		// Return a fallback path when home directory can't be determined
+		return "/tmp"
 	}
 
 	// Default to ~/Downloads - most browsers use this
@@ -138,10 +139,22 @@ func ParseDuration(s string) (time.Duration, error) {
 	
 	// Handle just numbers (assume minutes)
 	if num, err := strconv.Atoi(s); err == nil {
+		if num < 0 {
+			return 0, fmt.Errorf("duration cannot be negative: %d", num)
+		}
 		return time.Duration(num) * time.Minute, nil
 	}
 	
-	return time.ParseDuration(s)
+	// Parse standard duration format
+	duration, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, err
+	}
+	if duration < 0 {
+		return 0, fmt.Errorf("duration cannot be negative: %s", s)
+	}
+	
+	return duration, nil
 }
 
 // findFilesInDir recursively finds files in a directory

--- a/pkg/recent/recent_parseduration_test.go
+++ b/pkg/recent/recent_parseduration_test.go
@@ -1,0 +1,59 @@
+package recent
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{
+			name:  "empty string returns default 5 minutes",
+			input: "",
+			want:  5 * time.Minute,
+		},
+		{
+			name:  "positive number as minutes",
+			input: "10",
+			want:  10 * time.Minute,
+		},
+		{
+			name:    "negative number should error",
+			input:   "-5",
+			wantErr: true,
+		},
+		{
+			name:  "standard duration format",
+			input: "2h30m",
+			want:  2*time.Hour + 30*time.Minute,
+		},
+		{
+			name:    "negative duration should error",
+			input:   "-2h",
+			wantErr: true,
+		},
+		{
+			name:  "seconds format",
+			input: "30s",
+			want:  30 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseDuration(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseDuration() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("ParseDuration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fix `ParseDuration` to return an error for negative durations in both numeric and standard formats
- Improve `GetBrowserDownloadDir` to return a fallback path `/tmp` when home directory cannot be determined
- Add comprehensive tests for `ParseDuration` covering empty input, positive numbers, negative values, and standard duration strings

## Changes

### Core Functionality
- **ParseDuration**: Added checks to reject negative durations and return descriptive errors
- **GetBrowserDownloadDir**: Changed fallback from using an invalid home directory path to a safe `/tmp` directory

### Tests
- Added `TestParseDuration` with multiple cases:
  - Empty string returns default 5 minutes
  - Positive numbers parsed as minutes
  - Negative numbers and durations return errors
  - Standard duration strings parsed correctly

## Test plan
- [x] Run new `TestParseDuration` unit tests to verify correct parsing and error handling
- [x] Manual verification of fallback directory path when home directory is unavailable

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/25db768c-d5d8-43fe-ac78-82b15861a35b