### PR TITLE
Improve MCP tool descriptions to advertise force_text pattern

### DIFF
--- a/cmd/clippy/mcp/server.go
+++ b/cmd/clippy/mcp/server.go
@@ -65,10 +65,10 @@ func StartServer() error {
 	// Define copy tool
 	copyTool := mcp.NewTool(
 		"clipboard_copy",
-		mcp.WithDescription("Copy text or file to clipboard. CRITICAL: Use 'text' parameter for ANY generated content, code, messages, or text that will be pasted. Use 'file' parameter ONLY for existing files that need to be attached/uploaded. DEFAULT TO 'text' FOR ALL GENERATED CONTENT."),
+		mcp.WithDescription("Copy text or file to clipboard. CRITICAL: Use 'text' parameter for ANY generated content, code, messages, or text that will be pasted. Use 'file' parameter ONLY for existing files that need to be attached/uploaded. DEFAULT TO 'text' FOR ALL GENERATED CONTENT. PRO TIP: For iterative editing, write to a temp file then use file + force_text='true' to avoid regenerating full content each time."),
 		mcp.WithString("text", mcp.Description("Text content to copy - USE THIS for all generated content, code snippets, messages, emails, documentation, or any text that will be pasted")),
-		mcp.WithString("file", mcp.Description("File path to copy as file reference - ONLY use this for existing files on disk that need to be dragged/attached, NOT for generated content")),
-		mcp.WithString("force_text", mcp.Description("Set to 'true' to force copying file content as text (only with 'file' parameter)")),
+		mcp.WithString("file", mcp.Description("File path to copy as file reference - ONLY use this for existing files on disk that need to be dragged/attached, NOT for generated content. PRO TIP: Use with force_text='true' for efficient iterative editing of temp files.")),
+		mcp.WithString("force_text", mcp.Description("Set to 'true' to force copying file content as text (only with 'file' parameter). USEFUL PATTERN: Write code to /tmp/script.ext, edit incrementally with Edit tool, then copy with file='/tmp/script.ext' force_text='true' for efficient iterative development without regenerating full text.")),
 	)
 
 	// Add copy tool handler


### PR DESCRIPTION
## Summary
Enhance the MCP server tool descriptions to better advertise the efficient `force_text` pattern to users of the clippy MCP server.

## Why
When LLMs help users with iterative code editing (especially for production debugging), they often regenerate entire code blocks for small changes. The `force_text` pattern allows for more efficient editing:
1. Write to a temp file once
2. Use Edit tool for incremental changes
3. Copy with `file + force_text='true'` to get updated text

## Changes
- Added PRO TIP to main tool description explaining the pattern
- Enhanced `file` parameter description with usage hint  
- Expanded `force_text` description with concrete example workflow

## Impact
LLMs using the clippy MCP server will now discover and use this more efficient pattern, improving the user experience for iterative development tasks.

## Test plan
- [x] Verify MCP server still compiles and runs
- [x] Tool descriptions appear correctly in MCP discovery
- [ ] Test that LLMs pick up on the pattern from descriptions