### PR TITLE
feat: smart content type detection (v1.5.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 Notable changes to clippy.
 
+## [1.5.3] - 2025-10-20
+
+### Added
+
+- **Smart content type detection**: Clippy now automatically detects and sets proper clipboard types for structured text formats
+  - JSON content → sets `public.json` type
+  - HTML content → sets `public.html` type
+  - XML content → sets `public.xml` type
+  - Many other text formats are properly detected
+  - Receiving apps now handle content correctly (syntax highlighting, rendering, etc.)
+- **Manual MIME type override** with `--mime` flag
+  - `echo "data" | clippy --mime text/html` - force content as HTML
+  - `clippy -t file.txt --mime application/json` - treat file as JSON
+  - Accepts standard MIME types (text/html, application/json) or macOS UTIs
+- **Major advantage over pbcopy**: Unlike pbcopy which only sets plain text, clippy now provides rich type information
+
+### Changed
+
+- Text copying now uses auto-detection by default to set appropriate clipboard types
+- Added comprehensive list of textual MIME types for better content detection
+
 ## [1.5.2] - 2025-10-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Copy files from your terminal that actually paste into GUI apps. No more switchi
 
 `pbcopy` copies file _contents_, but GUI apps need file _references_. When you `pbcopy < image.png`, you can't paste it into Slack or email - those apps expect files, not raw bytes.
 
-Clippy bridges this gap by detecting what you want and using the right clipboard format:
+Clippy bridges this gap by detecting what you want and using the right clipboard format.
+
+**Plus:** Unlike `pbcopy` which only sets plain text, clippy auto-detects content types (HTML, JSON, XML) so receiving apps handle them properly:
 
 ```bash
 # Copy files as references (paste into any GUI app)
@@ -17,6 +19,10 @@ clippy *.jpg             # Multiple files at once
 
 # Pipe data as files
 curl -sL https://picsum.photos/300 | clippy  # Download → clipboard as file
+
+# Smart content type detection (pbcopy can't do this!)
+echo '{"key": "value"}' | clippy    # Auto-detects as JSON
+clippy -t page.html                 # Auto-detects as HTML
 
 # Copy your most recent download (immediate)
 clippy -r                # Grabs the file you just downloaded
@@ -88,7 +94,24 @@ clippy --clear         # Empty the clipboard
 echo -n | clippy       # Also clears the clipboard
 ```
 
-### 6. Helpful Flags
+### 6. Smart Content Type Detection
+
+Unlike `pbcopy` which only handles plain text, clippy automatically detects and sets proper content types:
+
+```bash
+# Auto-detection (receiving apps will recognize the format)
+echo '{"key": "value"}' | clippy          # Sets as JSON
+echo '<html>...</html>' | clippy          # Sets as HTML
+clippy -t data.xml                        # Sets as XML
+
+# Manual override with --mime flag
+echo "Plain text" | clippy --mime text/html        # Force as HTML
+clippy -t file.txt --mime application/json         # Treat as JSON
+```
+
+This means when you paste into apps that support rich content, they'll handle it correctly - JSON viewers will syntax highlight, HTML will render, etc.
+
+### 7. Helpful Flags
 
 ```bash
 clippy -v file.txt     # Show what happened

--- a/clippy_test.go
+++ b/clippy_test.go
@@ -1,0 +1,171 @@
+package clippy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gabriel-vasile/mimetype"
+)
+
+func TestIsTextualMimeType(t *testing.T) {
+	tests := []struct {
+		name     string
+		mimeType string
+		want     bool
+	}{
+		// Text types
+		{"plain text", "text/plain", true},
+		{"HTML", "text/html", true},
+		{"CSS", "text/css", true},
+		{"JavaScript text", "text/javascript", true},
+		{"XML text", "text/xml", true},
+		{"CSV text", "text/csv", true},
+
+		// Application types that are actually text
+		{"JSON", "application/json", true},
+		{"XML app", "application/xml", true},
+		{"JavaScript app", "application/javascript", true},
+		{"YAML", "application/x-yaml", true},
+		{"SQL", "application/sql", true},
+		{"GraphQL", "application/graphql", true},
+		{"XHTML", "application/xhtml+xml", true},
+		{"JSON-LD", "application/ld+json", true},
+		{"Atom feed", "application/atom+xml", true},
+		{"RSS", "application/rss+xml", true},
+
+		// Binary types (should return false)
+		{"PDF", "application/pdf", false},
+		{"ZIP", "application/zip", false},
+		{"JPEG", "image/jpeg", false},
+		{"PNG", "image/png", false},
+		{"MP3", "audio/mpeg", false},
+		{"MP4", "video/mp4", false},
+		{"Binary", "application/octet-stream", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTextualMimeType(tt.mimeType); got != tt.want {
+				t.Errorf("isTextualMimeType(%q) = %v, want %v", tt.mimeType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMimeToUTI(t *testing.T) {
+	tests := []struct {
+		name string
+		mime string
+		want string
+	}{
+		{"HTML", "text/html", "public.html"},
+		{"JSON", "application/json", "public.json"},
+		{"XML text", "text/xml", "public.xml"},
+		{"XML app", "application/xml", "public.xml"},
+		{"Plain text", "text/plain", "public.plain-text"},
+		{"RTF text", "text/rtf", "public.rtf"},
+		{"RTF app", "application/rtf", "public.rtf"},
+		{"Markdown", "text/markdown", "net.daringfireball.markdown"},
+		{"Unknown type", "application/unknown", "application/unknown"}, // Returns as-is
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mimeToUTI(tt.mime); got != tt.want {
+				t.Errorf("mimeToUTI(%q) = %v, want %v", tt.mime, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCopyTextWithAutoDetection(t *testing.T) {
+	// Note: These tests check the detection logic but can't test actual clipboard operations
+	// without mocking the clipboard package
+
+	tests := []struct {
+		name        string
+		content     string
+		wantUTI     string // Expected UTI that would be set
+		description string
+	}{
+		{
+			name:        "JSON content",
+			content:     `{"key": "value", "number": 123}`,
+			wantUTI:     "public.json",
+			description: "Should detect JSON and set public.json",
+		},
+		{
+			name:        "HTML content",
+			content:     `<!DOCTYPE html><html><body><h1>Test</h1></body></html>`,
+			wantUTI:     "public.html",
+			description: "Should detect HTML and set public.html",
+		},
+		{
+			name:        "XML content",
+			content:     `<?xml version="1.0"?><root><item>test</item></root>`,
+			wantUTI:     "public.xml",
+			description: "Should detect XML and set public.xml",
+		},
+		{
+			name:        "Plain text",
+			content:     "This is just plain text without any special format.",
+			wantUTI:     "", // Would use default CopyText
+			description: "Should fall back to plain text",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Detect MIME type as the function would
+			mtype := mimetype.Detect([]byte(tt.content))
+			mimeStr := mtype.String()
+
+			// Check what UTI would be selected
+			var expectedUTI string
+			switch {
+			case strings.HasPrefix(mimeStr, "text/html"):
+				expectedUTI = "public.html"
+			case mimeStr == "application/json":
+				expectedUTI = "public.json"
+			case strings.HasPrefix(mimeStr, "text/xml") || mimeStr == "application/xml":
+				expectedUTI = "public.xml"
+			default:
+				expectedUTI = ""
+			}
+
+			if expectedUTI != tt.wantUTI {
+				t.Errorf("Content detection failed for %s\nDetected MIME: %s\nExpected UTI: %s\nGot UTI: %s",
+					tt.name, mimeStr, tt.wantUTI, expectedUTI)
+			}
+		})
+	}
+}
+
+func TestCopyTextWithType(t *testing.T) {
+	// Test MIME to UTI conversion in CopyTextWithType
+	tests := []struct {
+		name           string
+		typeIdentifier string
+		wantUTI        string
+	}{
+		{"MIME type HTML", "text/html", "public.html"},
+		{"MIME type JSON", "application/json", "public.json"},
+		{"Direct UTI", "public.xml", "public.xml"},
+		{"Unknown MIME", "application/custom", "application/custom"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Check conversion logic
+			result := tt.typeIdentifier
+			if strings.Contains(result, "/") {
+				result = mimeToUTI(result)
+			}
+
+			if result != tt.wantUTI {
+				t.Errorf("Type conversion failed\nInput: %s\nExpected: %s\nGot: %s",
+					tt.typeIdentifier, tt.wantUTI, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Auto-detect and set proper clipboard types for JSON, HTML, XML, and other structured text
- Add `--mime` flag for manual MIME type override  
- Major advantage over pbcopy which only handles plain text

Fixes #11

## What's New

Unlike `pbcopy` which only sets plain text type, clippy now:
- **Auto-detects** content types and sets proper clipboard metadata
- **Manual override** with `--mime` flag when needed
- **Receiving apps** properly handle the content (syntax highlighting, rendering, etc.)

### Examples

```bash
# Auto-detection
echo '{"key": "value"}' | clippy    # Sets as JSON
clippy -t page.html                   # Sets as HTML

# Manual override  
echo "data" | clippy --mime text/html
clippy -t file.txt --mime application/json
```

## Test Results

Tested with actual clipboard inspection:
- ✅ JSON files set `public.json` type
- ✅ HTML files set `public.html` type  
- ✅ XML files set `public.xml` type
- ✅ Manual --mime flag works with both MIME types and UTIs
- ✅ All unit tests pass

## Version Bump

Updated to v1.5.3 (patch release for new feature)