### PR TITLE
docs: add badges to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Notable changes to clippy.
 
+## [Unreleased]
+
+### Added
+
+- README badges for Homebrew version, GitHub release, CI status, Go version, and license
+
 ## [1.5.3] - 2025-10-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Clippy 📎
 
+[![Homebrew](https://img.shields.io/homebrew/v/clippy?color=FBB040)](https://formulae.brew.sh/formula/clippy)
+[![Release](https://img.shields.io/github/v/release/neilberkman/clippy)](https://github.com/neilberkman/clippy/releases)
+[![CI](https://github.com/neilberkman/clippy/actions/workflows/release.yml/badge.svg)](https://github.com/neilberkman/clippy/actions/workflows/release.yml)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/neilberkman/clippy)](https://go.dev/)
+[![License](https://img.shields.io/github/license/neilberkman/clippy)](https://github.com/neilberkman/clippy/blob/main/LICENSE)
+
 Copy files from your terminal that actually paste into GUI apps. No more switching to Finder.
 
 **macOS only** - built specifically for the Mac clipboard system.


### PR DESCRIPTION
Add status badges to README for better project visibility:
- Homebrew version badge - shows current version in homebrew-core
- GitHub release badge - latest release version
- CI status badge - build status
- Go version badge - Go version requirement
- MIT license badge - license clarity

These are standard for professional Go/Homebrew projects and help users quickly see project status.