### PR TITLE
De-emphasize MIME type detection in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ Copy files from your terminal that actually paste into GUI apps. No more switchi
 
 `pbcopy` copies file _contents_, but GUI apps need file _references_. When you `pbcopy < image.png`, you can't paste it into Slack or email - those apps expect files, not raw bytes.
 
-Clippy bridges this gap by detecting what you want and using the right clipboard format.
-
-**Plus:** Unlike `pbcopy` which only sets plain text, clippy auto-detects content types (HTML, JSON, XML) so receiving apps handle them properly:
+Clippy bridges this gap by detecting what you want and using the right clipboard format:
 
 ```bash
 # Copy files as references (paste into any GUI app)
@@ -25,10 +23,6 @@ clippy *.jpg             # Multiple files at once
 
 # Pipe data as files
 curl -sL https://picsum.photos/300 | clippy  # Download → clipboard as file
-
-# Smart content type detection (pbcopy can't do this!)
-echo '{"key": "value"}' | clippy    # Auto-detects as JSON
-clippy -t page.html                 # Auto-detects as HTML
 
 # Copy your most recent download (immediate)
 clippy -r                # Grabs the file you just downloaded
@@ -100,22 +94,15 @@ clippy --clear         # Empty the clipboard
 echo -n | clippy       # Also clears the clipboard
 ```
 
-### 6. Smart Content Type Detection
+### 6. Content Type Detection
 
-Unlike `pbcopy` which only handles plain text, clippy automatically detects and sets proper content types:
+A nice bonus: clippy auto-detects content types (JSON, HTML, XML) so receiving apps handle them properly - something `pbcopy` can't do. This means when you paste into apps that support rich content, they'll handle it correctly - JSON viewers will syntax highlight, HTML will render, etc.
 
 ```bash
-# Auto-detection (receiving apps will recognize the format)
-echo '{"key": "value"}' | clippy          # Sets as JSON
-echo '<html>...</html>' | clippy          # Sets as HTML
-clippy -t data.xml                        # Sets as XML
-
-# Manual override with --mime flag
-echo "Plain text" | clippy --mime text/html        # Force as HTML
-clippy -t file.txt --mime application/json         # Treat as JSON
+echo '{"key": "value"}' | clippy          # Recognized as JSON
+clippy -t page.html                       # Recognized as HTML
+clippy -t file.txt --mime application/json  # Manual override when needed
 ```
-
-This means when you paste into apps that support rich content, they'll handle it correctly - JSON viewers will syntax highlight, HTML will render, etc.
 
 ### 7. Helpful Flags
 

--- a/cmd/clippy/main.go
+++ b/cmd/clippy/main.go
@@ -66,15 +66,6 @@ Examples:
   # Copy from curl
   curl -s https://example.com/image.jpg | clippy
 
-  # Smart content type detection (new!)
-  echo '{"key": "value"}' | clippy     # Auto-detects as JSON
-  clippy -t page.html                  # Auto-detects as HTML
-  clippy -t data.xml                   # Auto-detects as XML
-
-  # Manual MIME type override
-  echo "Custom data" | clippy --mime text/html     # Force as HTML
-  clippy -t file.txt --mime application/json       # Treat text file as JSON
-
   # Copy most recent file(s) from Downloads/Desktop/Documents
   clippy -r            # copy the most recent file
   clippy -r 3          # copy the 3 most recent files
@@ -102,6 +93,11 @@ Examples:
   # Clear clipboard
   clippy --clear               # empty the clipboard
   echo -n | clippy             # also clears the clipboard
+
+  # Content type detection (auto-detects JSON, HTML, XML)
+  echo '{"key": "value"}' | clippy     # Recognized as JSON
+  clippy -t page.html                  # Recognized as HTML
+  clippy -t file.txt --mime text/html  # Override type when needed
 
 Configuration:
   Create ~/.clippy.conf with:


### PR DESCRIPTION
Fixes the prominence of MIME type detection feature in README and help text.

- Moved MIME detection from "Why Clippy?" section to section 6 as a nice bonus
- Removed dated "new!" language to keep docs evergreen  
- Kept the useful explanation about syntax highlighting benefits

This addresses feedback about making the MIME feature too prominent after implementing it.