### PR TITLE
Maintain core/interface separation for file I/O

### DIFF
--- a/clippy.go
+++ b/clippy.go
@@ -218,6 +218,26 @@ func CopyTextWithType(text string, typeIdentifier string) error {
 	return clipboard.CopyTextWithType(text, typeIdentifier)
 }
 
+// CopyFileAsTextWithType copies a file's text content with a specific MIME type or UTI.
+// This is a core function that handles file I/O - interface layer should not read files directly.
+func CopyFileAsTextWithType(path string, typeIdentifier string) error {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("invalid path %s: %w", path, err)
+	}
+
+	if _, err := os.Stat(absPath); os.IsNotExist(err) {
+		return fmt.Errorf("file not found: %s", absPath)
+	}
+
+	content, err := os.ReadFile(absPath)
+	if err != nil {
+		return fmt.Errorf("could not read file %s: %w", absPath, err)
+	}
+
+	return CopyTextWithType(string(content), typeIdentifier)
+}
+
 // mimeToUTI converts common MIME types to macOS UTI
 func mimeToUTI(mime string) string {
 	switch mime {

--- a/cmd/clippy/main.go
+++ b/cmd/clippy/main.go
@@ -404,16 +404,10 @@ func handleFileMode(filePath string) {
 	// If mime type is specified, use it directly
 	if mimeType != "" && textMode {
 		logger.Debug("Using manual MIME type: %s", mimeType)
-		content, err := os.ReadFile(filePath)
+		// Core handles file I/O - interface just passes path and type
+		err := clippy.CopyFileAsTextWithType(filePath, mimeType)
 		if err != nil {
-			logger.Error("Could not read file %s: %v", filePath, err)
-			os.Exit(1)
-		}
-
-		// Use the specified MIME type
-		err = clippy.CopyTextWithType(string(content), mimeType)
-		if err != nil {
-			logger.Error("Could not copy with MIME type %s: %v", mimeType, err)
+			logger.Error("Could not copy file with MIME type %s: %v", mimeType, err)
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
Fixes a violation of the core/interface separation pattern where the CLI was reading files directly instead of delegating to the core layer.

## Problem
The CLI (interface) was reading file contents when the `--mime` flag was specified:
```go
content, err := os.ReadFile(filePath)  // ❌ Interface doing file I/O
err = clippy.CopyTextWithType(string(content), mimeType)
```

This violated the core/interface pattern because:
- File I/O is a core concern (happens regardless of interface type)
- Future interfaces (TUI, etc) would need to duplicate this logic
- Blurs the boundary between layers

## Solution
Added `CopyFileAsTextWithType()` function to the core layer that:
- Takes file path and type identifier as parameters
- Handles all file I/O internally
- Maintains clean separation of responsibilities

Now the interface just passes parameters to core:
```go
err := clippy.CopyFileAsTextWithType(filePath, mimeType)  // ✅ Core handles I/O
```

## Core/Interface Pattern
Following the principle from Saša Jurić's "Towards Maintainable Elixir":
- **Core**: Implements system behavior (file I/O, type detection, business logic)
- **Interface**: Exposes system to clients (flag parsing, output formatting)

## Testing
- All tests pass
- Manually verified `--mime` flag works correctly
- Auto-detection path still works as expected