### PR TITLE
Release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Notable changes to clippy.
 
 ## [Unreleased]
 
+## [1.6.0] - 2025-10-21
+
 ### Fixed
 
 - Clipboard priority now checks images before text (fixes "Copy Image" saving URL instead of image)


### PR DESCRIPTION
## Summary

Release v1.6.0 with major pasty enhancements for image pasting, format conversion, and RTFD support.

## What's New

### Fixed
- Clipboard priority now checks images before text (fixes "Copy Image" saving URL instead of image)

### Added
- Pasty saves browser images (auto-converts Safari's TIFF to PNG, 74-84% smaller)
- Smart image format conversion: specify target format via file extension (`pasty photo.jpg` converts to JPEG)
- Pasty handles rich text with embedded images (RTFD bundles from TextEdit/Notes)
- `--inspect` flag shows clipboard types and sizes for debugging
- `--plain` flag forces plain text extraction, stripping all formatting