### PR TITLE
Add platform checks to fail fast on non-macOS systems

### DIFF
--- a/cmd/clippy/main.go
+++ b/cmd/clippy/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -38,6 +39,13 @@ var (
 )
 
 func main() {
+	// Clippy only works on macOS
+	if runtime.GOOS != "darwin" {
+		fmt.Fprintf(os.Stderr, "Error: Clippy only works on macOS (detected: %s)\n", runtime.GOOS)
+		fmt.Fprintln(os.Stderr, "Clippy uses macOS-specific clipboard APIs and frameworks.")
+		os.Exit(1)
+	}
+
 	// Preprocess args to convert "-r 3" to "-r=3" for Cobra compatibility
 	os.Args = preprocessArgs(os.Args)
 

--- a/cmd/clippy/main_test.go
+++ b/cmd/clippy/main_test.go
@@ -5,11 +5,17 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
 
 func TestMain(m *testing.M) {
+	// Clippy only works on macOS
+	if runtime.GOOS != "darwin" {
+		panic("Clippy tests require macOS (detected: " + runtime.GOOS + ")")
+	}
+
 	// Build the binary for testing
 	cmd := exec.Command("go", "build", "-o", "clippy_test", ".")
 	if err := cmd.Run(); err != nil {

--- a/cmd/pasty/main.go
+++ b/cmd/pasty/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/neilberkman/clippy"
 	"github.com/neilberkman/clippy/cmd/internal/common"
@@ -24,6 +25,13 @@ var (
 )
 
 func main() {
+	// Pasty only works on macOS
+	if runtime.GOOS != "darwin" {
+		fmt.Fprintf(os.Stderr, "Error: Pasty only works on macOS (detected: %s)\n", runtime.GOOS)
+		fmt.Fprintln(os.Stderr, "Pasty uses macOS-specific clipboard APIs and frameworks.")
+		os.Exit(1)
+	}
+
 	var rootCmd = &cobra.Command{
 		Use:   "pasty [destination]",
 		Short: "Smart paste tool for macOS",


### PR DESCRIPTION
Fixes #27

Adds runtime platform detection to provide clear error messages instead of cryptic clipboard failures when running on non-macOS systems.

Test suite now fails early with clear message. Binaries exit immediately on non-macOS platforms.